### PR TITLE
Various fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PREFIX=/usr/local
 
 install:
+	install -m 755 monitor $(PREFIX)/bin
 	install -m 755 record $(PREFIX)/bin
 	ln -sf record $(PREFIX)/bin/stream

--- a/monitor
+++ b/monitor
@@ -1,11 +1,19 @@
 #!/bin/bash
 
-for pid in $(pgrep avpinput); do
-	echo "PROCESS $pid"
-	viu -h 20 "/tmp/avpinput_$pid.jpg"
-	i=1
-	echo -n "AUDIO CH "
-	for ch in $(cat "/tmp/avpinput_$pid.peak"); do echo -n "$i:${ch}dB "; i=$(($i+1)); done
-	echo
-	echo
-done
+show_monitor() {
+	for pid in $(pgrep avpinput); do
+		echo "PROCESS $pid"
+		viu -h 20 "/tmp/avpinput_$pid.jpg"
+		i=1
+		echo -n "AUDIO CH "
+		for ch in $(cat "/tmp/avpinput_$pid.peak"); do echo -n "$i:${ch}dB "; i=$(($i+1)); done
+		echo
+		echo
+	done
+}
+
+loop() {
+	while true; do clear; show_monitor; sleep 5; done
+}
+
+[ "$1" = "-c" ] && loop || show_monitor

--- a/record
+++ b/record
@@ -11,7 +11,7 @@ BUGFILE=/home/rpitv/livebug.svg
 PNGBUG=/home/armena/bug.png
 FILTERARGS=()
 MONO_STREAM=
-FFMPEG=/usr/local/bin/ffmpeg
+FFMPEG=/home/armena/ffmpeg/ffmpeg
 FFMPEG_PRESET=veryfast
 AVPINPUT_DECKLINK=/home/armena/exacore_work/avspipe/avpinput_decklink
 HTTPKEYER=/home/armena/exacore_work/keyer/http_keyer.rb
@@ -164,13 +164,12 @@ h264_1080() {
 		-nr 70 -g 60 -ab 256k $1"
 }
 
-
-#h264_1080() {
-#	raw_input -- "-vf yadif -f mpegts -s 1920x1080 -pix_fmt yuv420p \
-#		-vcodec libx264 -acodec mp3 -ar 48000 -ac 8 \
-#		-vpre ultrafast -maxrate $VBITRATE -bt 40k -bufsize 32M -threads 4 -r 29.97 \
-#		-nr 70 -g 60 -ab 64k $1"
-#}
+h264_1080_qsv() {
+	raw_input $MONO_STREAM -c 2 -- "-vaapi_device /dev/dri/renderD128 \
+		-vf 'yadif,format=nv12,hwupload' \
+		-vcodec h264_vaapi -acodec aac -ac 2 -ar 44100 \
+		-b:v $VBITRATE -r 29.97 -g 60 -ab 256k $1"
+}
 
 h264_480() {
 	raw_input -c 2 -- "-vf yadif -f flv -vf crop=1440:1080 -s 640x480 -pix_fmt yuv420p \
@@ -213,7 +212,7 @@ q)
 p)
 	# validate that this is a preset we know
 	case $OPTARG in
-	hd_mjpeg|sd_mjpeg|sd_mpeg|h264_480)
+	hd_mjpeg|sd_mjpeg|sd_mpeg|h264_1080|h264_1080_qsv|h264_480)
 		;;
 	*)
 		error_exit "unknown preset"

--- a/record
+++ b/record
@@ -8,12 +8,16 @@ FILE_PATH=/mnt/video-storage
 STREAM_URL=rtmp://video1.rpitv.org:1935/rpitv-live/rpitv-live
 BUG=0
 BUGFILE=/home/rpitv/livebug.svg
+PNGBUG=/home/armena/bug.png
 KEYERARGS=()
 MONO_STREAM=
+FFMPEG=/home/armena/ffmpeg/ffmpeg
 FFMPEG_PRESET=veryfast
-AVPINPUT_DECKLINK=/home/armena/exacore/avspipe/avpinput_decklink
-HTTPKEYER=/home/armena/exacore/keyer/http_keyer.rb
-SCOREBOARD=/bin/false
+AVPINPUT_DECKLINK=/home/armena/exacore_work/avspipe/avpinput_decklink
+HTTPKEYER=/home/armena/exacore_work/keyer/http_keyer.rb
+SCOREBOARD=/opt/scoreboard/scoreboard.sh
+
+set -eux
 
 # set some defaults based on whether run as 'record' or 'stream'
 case $0 in
@@ -101,7 +105,7 @@ mjpeg_input() {
 	# this should avoid deadlocks
 	exec $AVPINPUT_DECKLINK -R "${KEYERARGS[@]}" -c $CARD \
 		-j -q $QUALITY --channels $CHANNELS \
-		"ffmpeg \
+		"$FFMPEG \
 			-thread_queue_size 512 -probesize 32 \
 			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
 			-thread_queue_size 512 -f mjpeg -r 29.97 -i pipe:%v $@"
@@ -130,7 +134,7 @@ raw_input() {
 	# this tells ffmpeg to read less data when starting up.
 	exec $AVPINPUT_DECKLINK -R "${KEYERARGS[@]}" $MONO_MIX \
 		-c $CARD --channels $CHANNELS \
-		"ffmpeg -thread_queue_size 512 -probesize 32 \
+		"$FFMPEG -thread_queue_size 512 -probesize 32 \
 			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
 			-thread_queue_size 512 -probesize 32 \
 			-f rawvideo -r 29.97 -pix_fmt uyvy422 \
@@ -178,10 +182,13 @@ h264_480() {
 setup_keyer() {
 	case "$1" in
 	pnghttp)
-		KEYERARGS+=("--png-cg" "$HTTPKEYER -h :: -p 4567")
+		KEYERARGS+=("--cg-x" "0" "--cg-y" "0" "--png-cg" "$HTTPKEYER -h :: -p 4567")
+		;;
+	pngbug)
+		KEYERARGS+=("--cg-x" "0" "--cg-y" "0" "--png-cg" "$HTTPKEYER -h :: -p 3005 -f $PNGBUG")
 		;;
 	scoreboard)
-		KEYERARGS+=("--svg-cg" "$SCOREBOARD")
+		KEYERARGS+=("--cg-x" "150" "--cg-y" "50" "--svg-cg" "$SCOREBOARD")
 		;;
 	*)
 	error_exit "unknown key type"

--- a/record
+++ b/record
@@ -9,9 +9,9 @@ STREAM_URL=rtmp://video1.rpitv.org:1935/rpitv-live/rpitv-live
 BUG=0
 BUGFILE=/home/rpitv/livebug.svg
 PNGBUG=/home/armena/bug.png
-KEYERARGS=()
+FILTERARGS=()
 MONO_STREAM=
-FFMPEG=/home/armena/ffmpeg/ffmpeg
+FFMPEG=/usr/local/bin/ffmpeg
 FFMPEG_PRESET=veryfast
 AVPINPUT_DECKLINK=/home/armena/exacore_work/avspipe/avpinput_decklink
 HTTPKEYER=/home/armena/exacore_work/keyer/http_keyer.rb
@@ -103,7 +103,7 @@ mjpeg_input() {
 
 	# -probesize 32 on audio, which shouldn't need probing anyway
 	# this should avoid deadlocks
-	exec $AVPINPUT_DECKLINK -R "${KEYERARGS[@]}" -c $CARD \
+	exec $AVPINPUT_DECKLINK -R "${FILTERARGS[@]}" -c $CARD \
 		-j -q $QUALITY --channels $CHANNELS \
 		"$FFMPEG \
 			-thread_queue_size 512 -probesize 32 \
@@ -132,7 +132,7 @@ raw_input() {
 
 	# -probesize 32 is very important here especially on the audio input.
 	# this tells ffmpeg to read less data when starting up.
-	exec $AVPINPUT_DECKLINK -R "${KEYERARGS[@]}" $MONO_MIX \
+	exec $AVPINPUT_DECKLINK -R "${FILTERARGS[@]}" $MONO_MIX \
 		-c $CARD --channels $CHANNELS \
 		"$FFMPEG -thread_queue_size 512 -probesize 32 \
 			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
@@ -159,7 +159,7 @@ sd_mpeg() {
 
 h264_1080() {
 	raw_input $MONO_STREAM -c 2 -- "-vf yadif -s 1920x1080 -pix_fmt yuv420p \
-		-vcodec libx264 -acodec libmp3lame -ac 2 -ar 44100 \
+		-vcodec libx264 -acodec aac -ac 2 -ar 44100 \
 		-preset $FFMPEG_PRESET -maxrate $VBITRATE -bt 40k -bufsize 32M -threads 8 -r 29.97 \
 		-nr 70 -g 60 -ab 256k $1"
 }
@@ -174,7 +174,7 @@ h264_1080() {
 
 h264_480() {
 	raw_input -c 2 -- "-vf yadif -f flv -vf crop=1440:1080 -s 640x480 -pix_fmt yuv420p \
-		-vcodec libx264 -acodec libmp3lame -ac 2 -ar 44100 \
+		-vcodec libx264 -acodec aac -ac 2 -ar 44100 \
 		-vpre $FFMPEG_PRESET -b:v $VBITRATE -bt:v 40k -threads 4 -r 29.97 \
 		-nr 70 -g 60 -ab 64k $1"
 }
@@ -182,13 +182,13 @@ h264_480() {
 setup_keyer() {
 	case "$1" in
 	pnghttp)
-		KEYERARGS+=("--cg-x" "0" "--cg-y" "0" "--png-cg" "$HTTPKEYER -h :: -p 4567")
+		FILTERARGS+=("--cg-x" "0" "--cg-y" "0" "--png-cg" "$HTTPKEYER -h :: -p 4567")
 		;;
 	pngbug)
-		KEYERARGS+=("--cg-x" "0" "--cg-y" "0" "--png-cg" "$HTTPKEYER -h :: -p 3005 -f $PNGBUG")
+		FILTERARGS+=("--cg-x" "0" "--cg-y" "0" "--png-cg" "$HTTPKEYER -h :: -p 3005 -f $PNGBUG")
 		;;
 	scoreboard)
-		KEYERARGS+=("--cg-x" "150" "--cg-y" "50" "--svg-cg" "$SCOREBOARD")
+		FILTERARGS+=("--cg-x" "150" "--cg-y" "50" "--svg-cg" "$SCOREBOARD")
 		;;
 	*)
 	error_exit "unknown key type"
@@ -197,7 +197,7 @@ setup_keyer() {
 }
 
 OPTIND=1
-while getopts "c:p:q:bB:r:mX:" arg; do
+while getopts "c:p:q:bB:r:mX:o:" arg; do
 case $arg in
 c)
 	# validate if OPTARG is numeric
@@ -238,6 +238,9 @@ m)
 X)
 	setup_keyer "$OPTARG"
 	;;
+o)
+	FILTERARGS+=("-o" "$OPTARG")
+	;;
 \?)
 	usage
 	exit 1
@@ -249,7 +252,7 @@ X)
 esac
 done
 
-[ $BUG -eq 1 ] && KEYERARGS+=(-b "$BUGFILE")
+[ $BUG -eq 1 ] && FILTERARGS+=(-b "$BUGFILE")
 
 shift $((OPTIND-1))
 

--- a/record
+++ b/record
@@ -8,10 +8,12 @@ FILE_PATH=/mnt/video-storage
 STREAM_URL=rtmp://video1.rpitv.org:1935/rpitv-live/rpitv-live
 BUG=0
 BUGFILE=/home/rpitv/livebug.svg
-BUGARG=
+KEYERARGS=()
 MONO_STREAM=
 FFMPEG_PRESET=veryfast
-AVPINPUT_DECKLINK=/opt/exacore/avspipe/avpinput_decklink
+AVPINPUT_DECKLINK=/home/armena/exacore/avspipe/avpinput_decklink
+HTTPKEYER=/home/armena/exacore/keyer/http_keyer.rb
+SCOREBOARD=/bin/false
 
 # set some defaults based on whether run as 'record' or 'stream'
 case $0 in
@@ -97,7 +99,8 @@ mjpeg_input() {
 
 	# -probesize 32 on audio, which shouldn't need probing anyway
 	# this should avoid deadlocks
-	exec $AVPINPUT_DECKLINK -R -c $CARD -j -q $QUALITY --channels $CHANNELS \
+	exec $AVPINPUT_DECKLINK -R "${KEYERARGS[@]}" -c $CARD \
+		-j -q $QUALITY --channels $CHANNELS \
 		"ffmpeg \
 			-thread_queue_size 512 -probesize 32 \
 			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
@@ -125,7 +128,8 @@ raw_input() {
 
 	# -probesize 32 is very important here especially on the audio input.
 	# this tells ffmpeg to read less data when starting up.
-	exec $AVPINPUT_DECKLINK -R $BUGARG $MONO_MIX -c $CARD --channels $CHANNELS \
+	exec $AVPINPUT_DECKLINK -R "${KEYERARGS[@]}" $MONO_MIX \
+		-c $CARD --channels $CHANNELS \
 		"ffmpeg -thread_queue_size 512 -probesize 32 \
 			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
 			-thread_queue_size 512 -probesize 32 \
@@ -171,8 +175,22 @@ h264_480() {
 		-nr 70 -g 60 -ab 64k $1"
 }
 
+setup_keyer() {
+	case "$1" in
+	pnghttp)
+		KEYERARGS+=("--png-cg" "$HTTPKEYER -h :: -p 4567")
+		;;
+	scoreboard)
+		KEYERARGS+=("--svg-cg" "$SCOREBOARD")
+		;;
+	*)
+	error_exit "unknown key type"
+		;;
+	esac
+}
+
 OPTIND=1
-while getopts "c:p:q:bB:r:m" arg; do
+while getopts "c:p:q:bB:r:mX:" arg; do
 case $arg in
 c)
 	# validate if OPTARG is numeric
@@ -210,6 +228,9 @@ r)
 m)
 	MONO_STREAM=-m
 	;;
+X)
+	setup_keyer "$OPTARG"
+	;;
 \?)
 	usage
 	exit 1
@@ -221,7 +242,7 @@ m)
 esac
 done
 
-[ $BUG -eq 1 ] && BUGARG="-b $BUGFILE"
+[ $BUG -eq 1 ] && KEYERARGS+=(-b "$BUGFILE")
 
 shift $((OPTIND-1))
 

--- a/record
+++ b/record
@@ -95,9 +95,12 @@ mjpeg_input() {
 
 	shift $((OPTIND-1))
 
+	# -probesize 32 on audio, which shouldn't need probing anyway
+	# this should avoid deadlocks
 	exec $AVPINPUT_DECKLINK -R -c $CARD -j -q $QUALITY --channels $CHANNELS \
 		"ffmpeg \
-			-thread_queue_size 512 -f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
+			-thread_queue_size 512 -probesize 32 \
+			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
 			-thread_queue_size 512 -f mjpeg -r 29.97 -i pipe:%v $@"
 }
 
@@ -120,9 +123,13 @@ raw_input() {
 
 	shift $((OPTIND-1))
 
+	# -probesize 32 is very important here especially on the audio input.
+	# this tells ffmpeg to read less data when starting up.
 	exec $AVPINPUT_DECKLINK -R $BUGARG $MONO_MIX -c $CARD --channels $CHANNELS \
-		"ffmpeg -thread_queue_size 512 -f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
-			-thread_queue_size 512 -f rawvideo -r 29.97 -pix_fmt uyvy422 \
+		"ffmpeg -thread_queue_size 512 -probesize 32 \
+			-f s16le -ar 48000 -ac $CHANNELS -i pipe:%a \
+			-thread_queue_size 512 -probesize 32 \
+			-f rawvideo -r 29.97 -pix_fmt uyvy422 \
 			-s 1920x1080 -i pipe:%v $@"
 }
 


### PR DESCRIPTION
* Fixed ffmpeg deadlock by setting -probesize 32
* Improved support for keyers
* Support for loop outputs to additional capture cards
* Support for VAAPI accelerated ffmpeg